### PR TITLE
Allow GIFs to be animated

### DIFF
--- a/checkstyle_config/checkstyle_packages.xml
+++ b/checkstyle_config/checkstyle_packages.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+    <!DOCTYPE checkstyle-packages PUBLIC
+    "-//Puppy Crawl//DTD Package Names 1.0//EN"
+    "http://www.puppycrawl.com/dtds/packages_1_0.dtd">
+
+<checkstyle-packages>
+  <package name="jmemorize.checks"/>
+</checkstyle-packages>

--- a/checkstyle_config/gpl-header-check.txt
+++ b/checkstyle_config/gpl-header-check.txt
@@ -1,0 +1,17 @@
+^/\*
+^ \* jMemorize - Learning made easy \(and fun\) - A Leitner flashcards tool
+^ \* Copyright\(C\).*
+^ \*
+^ \* This program is free software; you can redistribute it and/or modify
+^ \* it under the terms of the GNU General Public License as published by
+^ \* the Free Software Foundation; .*
+^ \* .*any later version.
+^ \*
+^ \* This program is distributed in the hope that it will be useful,
+^ \* but WITHOUT ANY WARRANTY; without even the implied warranty of
+^ \* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE\.  See the
+^ \* GNU General Public License for more details.
+^ \*
+^ \* You should have received a copy of the GNU General Public License
+^ \* along with this program; if not, write to the Free Software
+^ \* Foundation, Inc\., .*

--- a/checkstyle_config/jmemorize-checkstyle.xml
+++ b/checkstyle_config/jmemorize-checkstyle.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    This configuration file was written by the eclipse-cs plugin configuration editor
+-->
+<!--
+Checkstyle-Configuration: jmemorize-checkstyle.xml
+Description:
+Checkstyle configuration for jmemorize
+-->
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<module name="Checker">
+    <property name="severity" value="warning"/>
+    <module name="TreeWalker">
+        <module name="DefaultComesLast"/>
+        <module name="DoubleCheckedLocking"/>
+        <module name="EqualsHashCode">
+            <property name="severity" value="error"/>
+        </module>
+        <module name="FallThrough"/>
+        <module name="IllegalCatch">
+            <property name="severity" value="ignore"/>
+        </module>
+        <module name="MissingSwitchDefault">
+            <property name="severity" value="ignore"/>
+        </module>
+        <module name="ModifiedControlVariable"/>
+        <module name="ArrayTrailingComma">
+            <property name="severity" value="ignore"/>
+        </module>
+        <module name="TabCharacter">
+            <metadata name="com.atlassw.tools.eclipse.checkstyle.lastEnabledSeverity" value="error"/>
+            <property name="severity" value="error"/>
+        </module>
+        <module name="LeftCurly">
+            <property name="severity" value="warning"/>
+            <property name="option" value="nl"/>
+            <property name="tokens" value="CLASS_DEF,CTOR_DEF,INTERFACE_DEF,LITERAL_CATCH,LITERAL_DO,LITERAL_FINALLY,LITERAL_FOR,LITERAL_IF,LITERAL_SWITCH,LITERAL_SYNCHRONIZED,LITERAL_TRY,LITERAL_WHILE,METHOD_DEF"/>
+        </module>
+        <module name="RightCurly">
+            <property name="severity" value="warning"/>
+            <property name="option" value="alone"/>
+        </module>
+        <module name="RegexpHeader">
+            <property name="severity" value="ignore"/>
+            <property name="headerFile" value="gpl-header-check.txt"/>
+        </module>
+        <module name="UpperEll">
+            <property name="severity" value="ignore"/>
+        </module>
+    <module name="jmemorize.checks.ExceptionLoggedCheck">
+            <property name="severity" value="warning"/>
+        </module>
+    </module>
+    <module name="NewlineAtEndOfFile">
+        <property name="severity" value="ignore"/>
+    </module>
+</module>

--- a/src/jmemorize/gui/swing/panels/CardSidePanel.java
+++ b/src/jmemorize/gui/swing/panels/CardSidePanel.java
@@ -150,7 +150,7 @@ public class CardSidePanel extends JPanel
             
             g.drawImage(m_image, 
                 left, top, left + w - 2*padding, top + h - 2*padding, 
-                0, 0, imgWidth, imgHeight, null);
+                0, 0, imgWidth, imgHeight, this);
         }
     }
     


### PR DESCRIPTION
Simple fix that allows GIF images to be animated.
Achieved by setting `ImageObserver` to `ScaledImagePanel` which automatically calls `repaint()` on frame changes.
